### PR TITLE
use rhel66 instead of 65

### DIFF
--- a/drupal-single.yaml
+++ b/drupal-single.yaml
@@ -52,7 +52,7 @@ parameters:
       - Debian 7 (Wheezy) (PVHVM)
       - Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
       - CentOS 6.5 (PVHVM)
-      - Red Hat Enterprise Linux 6.5 (PVHVM)
+      - Red Hat Enterprise Linux 6.6 (PVHVM)
       description: Must be a supported operating system.
 
   flavor:

--- a/tests.yaml
+++ b/tests.yaml
@@ -118,7 +118,7 @@ test-cases:
   create:
     parameters:
       flavor: 2GB Standard Instance
-      image: Red Hat Enterprise Linux 6.5 (PVHVM)
+      image: Red Hat Enterprise Linux 6.6 (PVHVM)
     timeout: 30
   resource_tests:
     ssh_private_key: { get_output: private_key }


### PR DESCRIPTION
The RHEL 6.5 image has been retired, so we need to use 6.6. 
