### PR TITLE
use `AllowOverride All` in Apache site config

### DIFF
--- a/drupal-single.yaml
+++ b/drupal-single.yaml
@@ -228,6 +228,7 @@ resources:
                    "recipe[rax-drupal-dir]",
                    "recipe[drupal]",
                    "recipe[dotmy-cnf]",
+                   "recipe[patch-drupalconf]",
                    "recipe[hollandbackup]",
                    "recipe[hollandbackup::mysqldump]",
                    "recipe[hollandbackup::main]",

--- a/site-cookbooks/patch-drupalconf/metadata.rb
+++ b/site-cookbooks/patch-drupalconf/metadata.rb
@@ -1,0 +1,9 @@
+maintainer 'Jason Boyles'
+maintainer_email 'jason.boyles@rackspace.com'
+license 'Apache 2.0'
+description 'Patch drupal.conf apache config file'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'
+name 'patch-drupalconf'
+
+depends 'drupal'

--- a/site-cookbooks/patch-drupalconf/recipes/default.rb
+++ b/site-cookbooks/patch-drupalconf/recipes/default.rb
@@ -1,0 +1,16 @@
+include_recipe 'drupal'
+
+# find the apache config template defined in drupal::default
+# and use our own template which includes "AllowOverride All"
+
+begin
+  t = resources(:template => "#{node['apache']['dir']}/sites-available/drupal.conf")
+  t.source "drupal.conf.erb"
+  t.cookbook "patch-drupalconf"
+  t.variables(:params => { :server_name => node['fqdn'],
+                           :server_aliases => node['fqdn'],
+                           :docroot => node['drupal']['dir'],
+                           :name => 'drupal' })
+rescue Chef::Exceptions::ResourceNotFound
+  Chef::Log.warn "could not find template #{node['apache']['dir']}/sites-available/drupal.conf to modify"
+end

--- a/site-cookbooks/patch-drupalconf/templates/default/drupal.conf.erb
+++ b/site-cookbooks/patch-drupalconf/templates/default/drupal.conf.erb
@@ -1,0 +1,19 @@
+<VirtualHost *:<%= @node[:drupal][:apache][:port] %>>
+  ServerName <%= @params[:server_name] %>
+  ServerAlias <% [*@params[:server_aliases]].each do |a| %><%= a %> <% end %>
+  DocumentRoot <%= @params[:docroot] %>
+
+  <Directory <%= @params[:docroot] %>>
+    Options FollowSymLinks
+    Order allow,deny
+    AllowOverride All
+    Allow from all
+  </Directory>
+
+  ErrorLog <%= @node[:apache][:log_dir] %>/<%= @params[:name] %>-error.log
+  CustomLog <%= @node[:apache][:log_dir] %>/<%= @params[:name] %>-access.log combined
+
+  <IfModule mod_rewrite.c>
+    RewriteEngine On
+  </IfModule>
+</VirtualHost>


### PR DESCRIPTION
`AllowOverride All` in the Apache directory configuration for the drupal
docroot allows extensions to modify apache behavior using .htaccess
files.

Fixes #9 