### PR TITLE
install latest major version 7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,21 @@ the `-P` flag to specify a custom parameter.
 * `domain`: Domain to be used with the Drupal site (Default: example.com)
 * `image`: Required: Server image used for all servers that are created as a
   part of this deployment. (Default: Ubuntu 12.04 LTS (Precise Pangolin))
-* `version`: Version of Drupal to install (Default: 7.32)
+* `version`: Version of Drupal to install (Default: 7)
 * `database_name`: Drupal database name (Default: drupal)
 * `flavor`: Required: Rackspace Cloud Server flavor to use. The size is based
   on the amount of RAM for the provisioned server. (Default: 4 GB Performance)
 * `chef_version`: Version of chef client to use (Default: 11.14.2)
 * `kitchen`: URL for a git repo containing required cookbooks (Default:
   https://github.com/rackspace-orchestration-templates/drupal-single.git)
+
+### Notes on the `version` parameter
+The `version` parameter is passed to [`drush`](https://github.com/drush-ops/drush),
+which downloads and installs drupal. Single integers will install the latest
+release of that major version. You may also specify specific sub-major releases
+such as `7.29` or `7.0-beta3`. The Chef cookbook used by this deployment to
+finalize the install only supports major version 7, so although [`drush`](https://github.com/drush-ops/drush)
+supports v6 and v8, you may only select v7 with this template.
 
 Outputs
 =======

--- a/drupal-single.yaml
+++ b/drupal-single.yaml
@@ -94,10 +94,11 @@ parameters:
     label: Drupal Version
     description: Version of Drupal to install
     type: string
-    default: "7.35"
+    default: "7"
     constraints:
-    - allowed_values:
-      - "7.35"
+    - allowed_pattern: '^7(\.?[0-9-a-zA-Z-])*$'
+      description: |
+        Must be a valid 7.x release.
 
   # Database and system user configuration
   database_name:


### PR DESCRIPTION
The `version` parameter is passed to the [`drush`](https://github.com/drush-ops/drush)
`dl` command which will download the latest major version release
if a single integer is specified. We limit this to version 7
because our drupal cookbook does not support v6 or v8.

This will result in us always installing the latest v7 release, so we get bug and security updates without manual intervention.